### PR TITLE
[feat/#10-2] 팀플 완주 한 상황 플로우, 방 생성 시 방 이미지 삽입 가능하도록 뷰 추가

### DIFF
--- a/teaming/app/(tabs)/chats/chat-menu.tsx
+++ b/teaming/app/(tabs)/chats/chat-menu.tsx
@@ -12,6 +12,7 @@ import { StatusBar } from 'expo-status-bar';
 import { router, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import LeaveTeamModal from './leave-team-modal';
+import CompleteTeamModal from './complete-team-modal';
 
 const { width } = Dimensions.get('window');
 
@@ -25,6 +26,7 @@ interface Participant {
 export default function ChatMenuScreen() {
   const { roomId, isLeader } = useLocalSearchParams();
   const [showLeaveModal, setShowLeaveModal] = useState(false);
+  const [showCompleteModal, setShowCompleteModal] = useState(false);
 
   // 팀장 여부 확인 (실제로는 API에서 가져올 데이터)
   const isTeamLeader = isLeader === 'true';
@@ -94,6 +96,24 @@ export default function ChatMenuScreen() {
   const handleCancelLeave = () => {
     // 모달 닫기
     setShowLeaveModal(false);
+  };
+
+  const handleCompleteTeam = () => {
+    // 팀플 완료 모달 표시
+    setShowCompleteModal(true);
+  };
+
+  const handleConfirmComplete = () => {
+    // 팀플 완료 처리
+    console.log('팀플 완료 처리');
+    setShowCompleteModal(false);
+    // 완료 후 홈 화면으로 이동하거나 다른 처리
+    router.push('/(tabs)/home');
+  };
+
+  const handleCancelComplete = () => {
+    // 모달 닫기
+    setShowCompleteModal(false);
   };
 
   return (
@@ -177,6 +197,22 @@ export default function ChatMenuScreen() {
           ))}
         </View>
 
+        {/* 팀플 완료 (팀장만) */}
+        {isTeamLeader && (
+          <View style={styles.section}>
+            <TouchableOpacity
+              style={styles.completeButton}
+              onPress={handleCompleteTeam}
+            >
+              <View style={styles.completeIcon}>
+                <Ionicons name="trophy" size={24} color="#FFD700" />
+              </View>
+              <Text style={styles.completeText}>팀플 완료</Text>
+              <Ionicons name="chevron-forward" size={20} color="#666666" />
+            </TouchableOpacity>
+          </View>
+        )}
+
         {/* 팀밍룸 나가기 */}
         <View style={styles.section}>
           <TouchableOpacity
@@ -197,6 +233,14 @@ export default function ChatMenuScreen() {
         visible={showLeaveModal}
         onClose={handleCancelLeave}
         onConfirm={handleConfirmLeave}
+        teamName="정치학 발표"
+      />
+
+      {/* 팀플 완료 모달 */}
+      <CompleteTeamModal
+        visible={showCompleteModal}
+        onClose={handleCancelComplete}
+        onConfirm={handleConfirmComplete}
         teamName="정치학 발표"
       />
     </View>
@@ -335,6 +379,27 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 16,
     color: '#FF3B30',
+    fontWeight: '500',
+  },
+  completeButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  completeIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: '#1A1A1A',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 12,
+  },
+  completeText: {
+    flex: 1,
+    fontSize: 16,
+    color: '#FFD700',
     fontWeight: '500',
   },
 });

--- a/teaming/app/(tabs)/chats/complete-team-modal.tsx
+++ b/teaming/app/(tabs)/chats/complete-team-modal.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Modal,
+  TouchableOpacity,
+  Dimensions,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+const { width } = Dimensions.get('window');
+
+interface CompleteTeamModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  teamName: string;
+}
+
+export default function CompleteTeamModal({
+  visible,
+  onClose,
+  onConfirm,
+  teamName,
+}: CompleteTeamModalProps) {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <View style={styles.overlay}>
+        <View style={styles.modalContainer}>
+          {/* 아이콘 */}
+          <View style={styles.iconContainer}>
+            <Ionicons name="checkmark-circle" size={60} color="#4CAF50" />
+          </View>
+
+          {/* 제목 */}
+          <Text style={styles.title}>팀플 완료</Text>
+
+          {/* 설명 */}
+          <Text style={styles.description}>
+            <Text style={styles.teamName}>{teamName}</Text> 팀플을{'\n'}
+            완수하셨습니까?
+          </Text>
+
+          {/* 버튼들 */}
+          <View style={styles.buttonContainer}>
+            <TouchableOpacity
+              style={[styles.button, styles.cancelButton]}
+              onPress={onClose}
+            >
+              <Text style={styles.cancelButtonText}>취소</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={[styles.button, styles.confirmButton]}
+              onPress={onConfirm}
+            >
+              <Text style={styles.confirmButtonText}>완료</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.7)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalContainer: {
+    backgroundColor: '#121216',
+    borderRadius: 20,
+    padding: 24,
+    width: width * 0.85,
+    maxWidth: 400,
+    borderWidth: 1,
+    borderColor: '#292929',
+  },
+  iconContainer: {
+    alignItems: 'center',
+    marginBottom: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: '#FFFFFF',
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  description: {
+    fontSize: 16,
+    color: '#B0B0B0',
+    textAlign: 'center',
+    lineHeight: 24,
+    marginBottom: 32,
+  },
+  teamName: {
+    color: '#4CAF50',
+    fontWeight: '600',
+  },
+  buttonContainer: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  button: {
+    flex: 1,
+    paddingVertical: 16,
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  cancelButton: {
+    backgroundColor: '#1A1A1A',
+    borderWidth: 1,
+    borderColor: '#292929',
+  },
+  confirmButton: {
+    backgroundColor: '#4CAF50',
+  },
+  cancelButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#FFFFFF',
+  },
+  confirmButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#FFFFFF',
+  },
+});

--- a/teaming/app/(tabs)/home/create-team.tsx
+++ b/teaming/app/(tabs)/home/create-team.tsx
@@ -8,10 +8,12 @@ import {
   TextInput,
   Image,
   Dimensions,
+  Alert,
 } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 import { router } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
+import * as ImagePicker from 'expo-image-picker';
 
 const { width } = Dimensions.get('window');
 
@@ -21,6 +23,7 @@ export default function CreateTeamScreen() {
   const [teamCount, setTeamCount] = useState(3);
   const [selectedRoom, setSelectedRoom] = useState('basic');
   const [emails, setEmails] = useState(['', '', '']);
+  const [roomImage, setRoomImage] = useState<string | null>(null);
 
   const handleBackPress = () => {
     router.back();
@@ -47,6 +50,28 @@ export default function CreateTeamScreen() {
     const newEmails = [...emails];
     newEmails[index] = text;
     setEmails(newEmails);
+  };
+
+  const handleSelectRoomImage = async () => {
+    try {
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        allowsEditing: true,
+        aspect: [1, 1],
+        quality: 1,
+        allowsMultipleSelection: false, // 한 장만 선택 가능
+      });
+
+      if (!result.canceled && result.assets.length > 0) {
+        setRoomImage(result.assets[0].uri);
+      }
+    } catch (error) {
+      Alert.alert('오류', '이미지를 선택하는 중 오류가 발생했습니다.');
+    }
+  };
+
+  const handleRemoveRoomImage = () => {
+    setRoomImage(null);
   };
 
   // 팀원수에 맞춰 이메일 배열 조정
@@ -112,6 +137,37 @@ export default function CreateTeamScreen() {
             placeholder="팀플 제목을 입력해주세요"
             placeholderTextColor="#666666"
           />
+        </View>
+
+        {/* 채팅방 이미지 */}
+        <View style={styles.inputSection}>
+          <Text style={styles.inputLabel}>채팅방 이미지</Text>
+          <TouchableOpacity
+            style={styles.imageContainer}
+            onPress={handleSelectRoomImage}
+          >
+            {roomImage ? (
+              <Image source={{ uri: roomImage }} style={styles.roomImage} />
+            ) : (
+              <View style={styles.imagePlaceholder}>
+                <Ionicons name="camera" size={32} color="#666666" />
+                <Text style={styles.placeholderText}>이미지 선택</Text>
+              </View>
+            )}
+          </TouchableOpacity>
+          {roomImage && (
+            <TouchableOpacity
+              style={styles.removeImageButton}
+              onPress={handleRemoveRoomImage}
+            >
+              <Text style={styles.removeImageText}>이미지 제거</Text>
+            </TouchableOpacity>
+          )}
+          {!roomImage && (
+            <Text style={styles.imageInfoText}>
+              💡 이미지를 선택하지 않을 시 기본 이미지로 생성됩니다.
+            </Text>
+          )}
         </View>
 
         {/* 부제목 및 한줄소개 */}
@@ -484,5 +540,53 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: 'bold',
     color: '#FFFFFF',
+  },
+  imageContainer: {
+    width: 120,
+    height: 120,
+    borderRadius: 12,
+    backgroundColor: '#121216',
+    borderWidth: 1,
+    borderColor: '#292929',
+    alignItems: 'center',
+    justifyContent: 'center',
+    alignSelf: 'center',
+    position: 'relative',
+  },
+  roomImage: {
+    width: 120,
+    height: 120,
+    borderRadius: 12,
+  },
+  imagePlaceholder: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  placeholderText: {
+    fontSize: 12,
+    color: '#666666',
+    marginTop: 8,
+  },
+  removeImageButton: {
+    alignSelf: 'center',
+    marginTop: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    backgroundColor: '#1A1A1A',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#292929',
+  },
+  removeImageText: {
+    fontSize: 14,
+    color: '#FF3B30',
+    fontWeight: '500',
+  },
+  imageInfoText: {
+    fontSize: 12,
+    color: '#888888',
+    textAlign: 'center',
+    marginTop: 12,
+    lineHeight: 16,
   },
 });


### PR DESCRIPTION
**뷰 구현 남은 부분**

- 안읽은 사람 보여주기 - 웹소켓 연동 후 구현 예정
- 팀플 완주 한 상황 플로우 (팀장 기준 완주 버튼 만드는 간단한 로직으로 할 예정) ✅
- 방 생성 시 방 이미지 삽입 가능하도록 ✅
- 마이페이지 기프티콘 뷰 - 기프티콘 연계 후 구현 예정
- 채팅방 생성할 때 이메일 빼고 결제 후 결제코드 + 링크 주는걸로 결정 - 결제 후 구현 예정
- 본인의 과제 생성 가능 뷰
- 자료실에서 과제 파일은 없애고 채팅 파일 시간순으로 볼 수 있게
- 과제방을 만들어서 거기서 할당된 과제들 확인할 수 있고 제출된 과제들도 그 과제들에 포함되어있으니 그것도 다운로드 가능하도록 (조금 무게감 있게)
- 채팅방에서 + 버튼이 있고, 이미지 or 파일 넣을 수 있도록 - 필요 요소 결정할 것

결제 관련 뷰 - 결제 기능 탑재되면 구현할 예정

- 방 생성시 팀장 결제 유도
- 초대코드로 방 입장시 결제 유도